### PR TITLE
Fix --bottom, add --center

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,6 +26,7 @@ have_bemenu_set_bottom = compiler.has_function(
 conf_data = configuration_data()
 
 conf_data.set_quoted('PROJECT_NAME', meson.project_name())
+conf_data.set10('HAVE_BEMENU_SET_BOTTOM', have_bemenu_set_bottom)
 
 configure_file(configuration: conf_data, output : 'config.h')
 

--- a/meson.build
+++ b/meson.build
@@ -23,10 +23,17 @@ have_bemenu_set_bottom = compiler.has_function(
   dependencies : [ bemenu ],
 )
 
+have_bemenu_set_align = compiler.has_function(
+  'bm_menu_set_align',
+  prefix : '#include <bemenu.h>',
+  dependencies : [ bemenu ],
+)
+
 conf_data = configuration_data()
 
 conf_data.set_quoted('PROJECT_NAME', meson.project_name())
 conf_data.set10('HAVE_BEMENU_SET_BOTTOM', have_bemenu_set_bottom)
+conf_data.set10('HAVE_BEMENU_SET_ALIGN', have_bemenu_set_align)
 
 configure_file(configuration: conf_data, output : 'config.h')
 

--- a/options.c
+++ b/options.c
@@ -24,8 +24,11 @@
 	X("scf", "Scrollbar foreground color", scollbar_foreground_color, BM_COLOR_SCROLLBAR_FG) \
 
 static int debug;
-#if HAVE_BEMENU_SET_BOTTOM
+#if HAVE_BEMENU_SET_BOTTOM || HAVE_BEMENU_SET_ALIGN
 static int bottom;
+#endif
+#if HAVE_BEMENU_SET_ALIGN
+static int center;
 #endif
 static int no_overlap;
 static int monitor;
@@ -41,8 +44,11 @@ COLORS
 
 static struct poptOption optionsTable[] = {
 	{ "debug", '\0', POPT_ARG_NONE, &debug, 0, NULL, NULL },
-#if HAVE_BEMENU_SET_BOTTOM
+#if HAVE_BEMENU_SET_BOTTOM || HAVE_BEMENU_SET_ALIGN
 	{ "bottom", 'b', POPT_ARG_NONE, &bottom, 0, NULL, NULL },
+#endif
+#if HAVE_BEMENU_SET_ALIGN
+	{ "center", 'c', POPT_ARG_NONE, &center, 0, NULL, NULL },
 #endif
 	{ "no-overlap", 'n', POPT_ARG_NONE, &no_overlap, 0, NULL, NULL },
 	{ "monitor", 'm', POPT_ARG_INT, &monitor, 0, "Monitor", NULL },
@@ -119,6 +125,12 @@ void apply_options(struct bm_menu *menu) {
 
 #if HAVE_BEMENU_SET_BOTTOM
 	bm_menu_set_bottom(menu, bottom);
+#endif
+#if HAVE_BEMENU_SET_ALIGN
+	enum bm_align align = BM_ALIGN_TOP;
+	if (bottom) align = BM_ALIGN_BOTTOM;
+	if (center) align = BM_ALIGN_CENTER;
+	bm_menu_set_align(menu, align);
 #endif
 	bm_menu_set_panel_overlap(menu, !no_overlap);
 	bm_menu_set_monitor(menu, monitor);

--- a/options.c
+++ b/options.c
@@ -24,7 +24,9 @@
 	X("scf", "Scrollbar foreground color", scollbar_foreground_color, BM_COLOR_SCROLLBAR_FG) \
 
 static int debug;
+#if HAVE_BEMENU_SET_BOTTOM
 static int bottom;
+#endif
 static int no_overlap;
 static int monitor;
 static int height;
@@ -39,7 +41,9 @@ COLORS
 
 static struct poptOption optionsTable[] = {
 	{ "debug", '\0', POPT_ARG_NONE, &debug, 0, NULL, NULL },
+#if HAVE_BEMENU_SET_BOTTOM
 	{ "bottom", 'b', POPT_ARG_NONE, &bottom, 0, NULL, NULL },
+#endif
 	{ "no-overlap", 'n', POPT_ARG_NONE, &no_overlap, 0, NULL, NULL },
 	{ "monitor", 'm', POPT_ARG_INT, &monitor, 0, "Monitor", NULL },
 	{ "line-height", 'H', POPT_ARG_INT, &height, 0, "Height for each menu line", NULL },


### PR DESCRIPTION
This PR contains two commits. The first fixes the `--bottom` implementation (so that the build system can actually enable the feature). The second adds support for the new `bm_menu_set_align()` interface that replaced `bm_menu_set_bottom()` of older releases to implement `--bottom` and `--center`. Hence, `--bottom` should now work with both older and current releases of bemenu, but `--center` will only work when `bm_menu_set_align()` is available.