### PR TITLE
pinentry: fix wild pointer

### DIFF
--- a/pinentry_bemenu.c
+++ b/pinentry_bemenu.c
@@ -68,7 +68,7 @@ static char *make_title(void) {
 	else if (prompt)
 		return strdup(prompt);
 
-	if (r == -1)
+	if (r == -1 || (!title && !desc && !prompt))
 		return NULL;
 
 	return p;


### PR DESCRIPTION
this commit fixes an unlikely wild pointer,
when title, desc, and prompt is not set, make_title will return a wild pointer