### PR TITLE
Make use of new bemenu password indicator option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -29,11 +29,22 @@ have_bemenu_set_align = compiler.has_function(
   dependencies : [ bemenu ],
 )
 
+bemenu_password_indicator_code = '''#include<bemenu.h>
+int main(void) {
+  return BM_PASSWORD_INDICATOR;
+}
+'''
+have_bemenu_password_indicator = compiler.compiles(
+  bemenu_password_indicator_code,
+  name : 'BM_PASSWORD_INDICATOR'
+)
+
 conf_data = configuration_data()
 
 conf_data.set_quoted('PROJECT_NAME', meson.project_name())
 conf_data.set10('HAVE_BEMENU_SET_BOTTOM', have_bemenu_set_bottom)
 conf_data.set10('HAVE_BEMENU_SET_ALIGN', have_bemenu_set_align)
+conf_data.set10('HAVE_BEMENU_PASSWORD_INDICATOR', have_bemenu_password_indicator)
 
 configure_file(configuration: conf_data, output : 'config.h')
 

--- a/options.c
+++ b/options.c
@@ -39,6 +39,9 @@ static int center;
 #endif
 static int no_overlap;
 static char *monitor;
+#ifdef HAVE_BEMENU_PASSWORD_INDICATOR
+static char *password;
+#endif
 static int height;
 static char *font;
 static char *display;
@@ -59,6 +62,9 @@ static struct poptOption optionsTable[] = {
 #endif
 	{ "no-overlap", 'n', POPT_ARG_NONE, &no_overlap, 0, NULL, NULL },
 	{ "monitor", 'm', POPT_ARG_STRING, &monitor, 0, "Index of the monitor to use, or \"focused\" or \"all\"", NULL },
+#ifdef HAVE_BEMENU_PASSWORD_INDICATOR
+	{ "password", 'x', POPT_ARG_STRING, &password, 0, "Handling of input characters: \"none\", or \"hide\" or \"indicator\"", NULL },
+#endif
 	{ "line-height", 'H', POPT_ARG_INT, &height, 0, "Height for each menu line", NULL },
 	{ "fn", '\0', POPT_ARG_STRING, &font, 0, "Font", NULL },
 	{ "display", 'D', POPT_ARG_STRING, &display, 0, "Set the X display", NULL },
@@ -160,6 +166,18 @@ void apply_options(struct bm_menu *menu) {
 #endif
 	bm_menu_set_panel_overlap(menu, !no_overlap);
 	bm_menu_set_monitor(menu, get_monitor_idx(monitor));
+#ifdef HAVE_BEMENU_PASSWORD_INDICATOR
+	if (!password || !strcmp(password, "hide"))
+		bm_menu_set_password(menu, BM_PASSWORD_HIDE);
+	else if (!strcmp(password, "none"))
+		bm_menu_set_password(menu, BM_PASSWORD_NONE);
+	else if (!strcmp(password, "indicator"))
+		bm_menu_set_password(menu, BM_PASSWORD_INDICATOR);
+	else
+		bm_menu_set_password(menu, BM_PASSWORD_HIDE);
+#else
+	bm_menu_set_password(menu, true);
+#endif
 	bm_menu_set_line_height(menu, height);
 	bm_menu_set_font(menu, font);
 	if (ignore_case) {

--- a/pinentry_bemenu.c
+++ b/pinentry_bemenu.c
@@ -87,7 +87,11 @@ static struct bm_item *run_menu(struct bm_menu *menu) {
 	title = make_title();
 	bm_menu_set_title(menu, title);
 	free(title);
+#ifdef HAVE_BEMENU_PASSWORD_INDICATOR
+	bm_menu_set_password(menu, BM_PASSWORD_INDICATOR);
+#else
 	bm_menu_set_password(menu, true);
+#endif
 
 	uint32_t unicode;
 	enum bm_key key;

--- a/pinentry_bemenu.c
+++ b/pinentry_bemenu.c
@@ -87,11 +87,6 @@ static struct bm_item *run_menu(struct bm_menu *menu) {
 	title = make_title();
 	bm_menu_set_title(menu, title);
 	free(title);
-#ifdef HAVE_BEMENU_PASSWORD_INDICATOR
-	bm_menu_set_password(menu, BM_PASSWORD_INDICATOR);
-#else
-	bm_menu_set_password(menu, true);
-#endif
 
 	uint32_t unicode;
 	enum bm_key key;


### PR DESCRIPTION
This option [was added in bemenu 0.6.17](https://github.com/Cloudef/bemenu/commit/d91346605004d117a73a59223fe034964a706ca7), when enable it displays asterisks instead of hiding the input text entirely. This is also what pinentry-gtk does and I think it's much more user friendly as it clearly indicates that input has been received by bemenu-pinentry.